### PR TITLE
Refactored HandlerRegistry implementation

### DIFF
--- a/docs/src/Modules/Collections/HandlerRegistry.rst
+++ b/docs/src/Modules/Collections/HandlerRegistry.rst
@@ -1,7 +1,7 @@
 HandlerRegistry
 ===============
 
-The ``HandlerRegistry<T>`` is a flexible collection that stores conditional
+The ``HandlerRegistry`` is a flexible collection that stores conditional
 handlers - pairs of predicates and actions that can be executed based on
 runtime conditions. It's particularly useful for implementing
 chain-of-responsibility patterns, message routing, or conditional processing
@@ -25,20 +25,20 @@ Basic Usage
 
 .. code-block:: csharp
 
-   var registry = new HandlerRegistry<string>();
+   var registry = new HandlerRegistry();
 
    // Register handlers with conditions
-   registry.Register(
+   registry.Register<string>(
        canHandle: s => s.StartsWith("ERROR"),
        handler: s => Console.WriteLine($"Error logged: {s}")
    );
 
-   registry.Register(
+   registry.Register<string>(
        canHandle: s => s.StartsWith("WARN"),
        handler: s => Console.WriteLine($"Warning logged: {s}")
    );
 
-   registry.Register(
+   registry.Register<string>(
        canHandle: s => s.Contains("URGENT"),
        handler: s => SendAlert(s)
    );
@@ -50,40 +50,6 @@ Basic Usage
    // Execute all matching handlers
    registry.HandleAll("URGENT WARN: System overload");   // Logs warning AND sends alert
 
-Core Methods
-------------
-
-**Registration**
-
-.. code-block:: csharp
-
-   registry.Register(canHandle, handler);
-
-**Execution**
-
-.. code-block:: csharp
-
-   // Execute first matching handler
-   bool wasHandled = registry.Handle(item);
-
-   // Execute all matching handlers
-   int handlersExecuted = registry.HandleAll(item);
-
-   // Check if any handler can process without executing
-   bool canProcess = registry.CanHandle(item);
-
-**Management**
-
-.. code-block:: csharp
-
-   // Get current handler count
-   int count = registry.Count;
-
-   // Remove all handlers and clear stash
-   registry.Clear();
-
-   // Get matching handlers without executing
-   var handlers = registry.GetMatchingHandlers(item);
 
 Stashing Handlers
 -----------------
@@ -93,18 +59,18 @@ and work with a different set of handlers:
 
 .. code-block:: csharp
 
-   var registry = new HandlerRegistry<string>();
+   var registry = new HandlerRegistry();
 
    // Register production handlers
-   registry.Register(s => s.StartsWith("INFO"), s => LogToFile(s));
-   registry.Register(s => s.StartsWith("ERROR"), s => LogToDatabase(s));
+   registry.Register<string>(s => s.StartsWith("INFO"), s => LogToFile(s));
+   registry.Register<string>(s => s.StartsWith("ERROR"), s => LogToDatabase(s));
 
    // Stash production handlers
    registry.Stash();
 
    // Register test handlers
-   registry.Register(s => s.StartsWith("INFO"), s => LogToConsole(s));
-   registry.Register(s => s.StartsWith("ERROR"), s => LogToConsole(s));
+   registry.Register<string>(s => s.StartsWith("INFO"), s => LogToConsole(s));
+   registry.Register<string>(s => s.StartsWith("ERROR"), s => LogToConsole(s));
 
    // Run tests with console logging
    registry.Handle("INFO: Test message");
@@ -126,14 +92,14 @@ Common Use Cases
 
 .. code-block:: csharp
 
-   var messageRegistry = new HandlerRegistry<Message>();
+   var messageRegistry = new HandlerRegistry();
 
-   messageRegistry.Register(
+   messageRegistry.Register<Message>(
        canHandle: msg => msg.Type == MessageType.Command,
        handler: msg => commandProcessor.Process(msg)
    );
 
-   messageRegistry.Register(
+   messageRegistry.Register<Message>(
        canHandle: msg => msg.Type == MessageType.Event,
        handler: msg => eventStore.Save(msg)
    );
@@ -142,14 +108,14 @@ Common Use Cases
 
 .. code-block:: csharp
 
-   var routeRegistry = new HandlerRegistry<HttpRequest>();
+   var routeRegistry = new HandlerRegistry();
 
-   routeRegistry.Register(
+   routeRegistry.Register<HttpRequest>(
        canHandle: req => req.Path.StartsWith("/api/users"),
        handler: req => userController.Handle(req)
    );
 
-   routeRegistry.Register(
+   routeRegistry.Register<HttpRequest>(
        canHandle: req => req.Path.StartsWith("/api/orders"),
        handler: req => orderController.Handle(req)
    );
@@ -158,14 +124,14 @@ Common Use Cases
 
 .. code-block:: csharp
 
-   var validatorRegistry = new HandlerRegistry<Order>();
+   var validatorRegistry = new HandlerRegistry();
 
-   validatorRegistry.Register(
+   validatorRegistry.Register<Order>(
        canHandle: order => order.Amount > 1000,
        handler: order => order.RequiresApproval = true
    );
 
-   validatorRegistry.Register(
+   validatorRegistry.Register<Order>(
        canHandle: order => order.Customer.IsVip,
        handler: order => order.Priority = Priority.High
    );

--- a/src/Servus.Core.Tests/Collections/HandlerRegistryTests.cs
+++ b/src/Servus.Core.Tests/Collections/HandlerRegistryTests.cs
@@ -9,21 +9,32 @@ namespace Servus.Core.Tests.Collections;
 [TestClass]
 public class HandlerRegistryTests
 {
-    private HandlerRegistry<string> _registry = new();
+    private HandlerRegistry _registry = new();
     private List<string> _handledItems = [];
 
     [TestInitialize]
     public void Setup()
     {
-        _registry = new HandlerRegistry<string>();
+        _registry = new HandlerRegistry();
         _handledItems = [];
+    }
+
+    [TestMethod]
+    public void Register_WithoutCondition_ShouldNotThrow()
+    {
+        // Arrange & Act & Assert
+        _registry.Register<string>(s => _handledItems.Add(s));
+        
+        Assert.AreEqual(1, _registry.Count);
+        Assert.IsTrue(_registry.Handle("test"));
+        Assert.ContainsSingle(_handledItems);
     }
 
     [TestMethod]
     public void Register_WithValidParameters_ShouldNotThrow()
     {
         // Arrange & Act & Assert
-        _registry.Register(s => s.StartsWith("test"), s => _handledItems.Add(s));
+        _registry.Register<string>(s => s.StartsWith("test"), s => _handledItems.Add(s));
         
         Assert.AreEqual(1, _registry.Count);
     }
@@ -33,7 +44,7 @@ public class HandlerRegistryTests
     {
         // Arrange, Act & Assert
         Assert.ThrowsExactly<ArgumentNullException>(() =>
-            _registry.Register(null!, s => _handledItems.Add(s)));
+            _registry.Register<string>(null!, s => _handledItems.Add(s)));
     }
 
     [TestMethod]
@@ -41,14 +52,14 @@ public class HandlerRegistryTests
     {
         // Arrange, Act & Assert
         Assert.ThrowsExactly<ArgumentNullException>(() =>
-            _registry.Register(_ => true, null!));
+            _registry.Register<string>(_ => true, null!));
     }
 
     [TestMethod]
     public void Handle_WithMatchingHandler_ShouldExecuteHandlerAndReturnTrue()
     {
         // Arrange
-        _registry.Register(s => s.StartsWith("test"), s => _handledItems.Add($"handled: {s}"));
+        _registry.Register<string>(s => s.StartsWith("test"), s => _handledItems.Add($"handled: {s}"));
         
         // Act
         var result = _registry.Handle("test item");
@@ -63,7 +74,7 @@ public class HandlerRegistryTests
     public void Handle_WithNoMatchingHandler_ShouldReturnFalse()
     {
         // Arrange
-        _registry.Register(s => s.StartsWith("test"), s => _handledItems.Add(s));
+        _registry.Register<string>(s => s.StartsWith("test"), s => _handledItems.Add(s));
         
         // Act
         var result = _registry.Handle("other item");
@@ -77,8 +88,8 @@ public class HandlerRegistryTests
     public void Handle_WithMultipleMatchingHandlers_ShouldExecuteOnlyFirst()
     {
         // Arrange
-        _registry.Register(s => s.Contains("test"), _ => _handledItems.Add("first"));
-        _registry.Register(s => s.Contains("test"), _ => _handledItems.Add("second"));
+        _registry.Register<string>(s => s.Contains("test"), _ => _handledItems.Add("first"));
+        _registry.Register<string>(s => s.Contains("test"), _ => _handledItems.Add("second"));
         
         // Act
         var result = _registry.Handle("test item");
@@ -93,9 +104,9 @@ public class HandlerRegistryTests
     public void HandleAll_WithMultipleMatchingHandlers_ShouldExecuteAllAndReturnCount()
     {
         // Arrange
-        _registry.Register(s => s.Contains("test"), _ => _handledItems.Add("first"));
-        _registry.Register(s => s.Contains("test"), _ => _handledItems.Add("second"));
-        _registry.Register(s => s.StartsWith("other"), _ => _handledItems.Add("third"));
+        _registry.Register<string>(s => s.Contains("test"), _ => _handledItems.Add("first"));
+        _registry.Register<string>(s => s.Contains("test"), _ => _handledItems.Add("second"));
+        _registry.Register<string>(s => s.StartsWith("other"), _ => _handledItems.Add("third"));
         var expected = new[] {"first", "second"};
         
         // Act
@@ -111,7 +122,7 @@ public class HandlerRegistryTests
     public void HandleAll_WithNoMatchingHandlers_ShouldReturnZero()
     {
         // Arrange
-        _registry.Register(s => s.StartsWith("test"), s => _handledItems.Add(s));
+        _registry.Register<string>(s => s.StartsWith("test"), s => _handledItems.Add(s));
         
         // Act
         var result = _registry.HandleAll("other item");
@@ -125,7 +136,7 @@ public class HandlerRegistryTests
     public void CanHandle_WithMatchingHandler_ShouldReturnTrue()
     {
         // Arrange
-        _registry.Register(s => s.StartsWith("test"), s => _handledItems.Add(s));
+        _registry.Register<string>(s => s.StartsWith("test"), s => _handledItems.Add(s));
         
         // Act
         var result = _registry.CanHandle("test item");
@@ -139,7 +150,7 @@ public class HandlerRegistryTests
     public void CanHandle_WithNoMatchingHandler_ShouldReturnFalse()
     {
         // Arrange
-        _registry.Register(s => s.StartsWith("test"), s => _handledItems.Add(s));
+        _registry.Register<string>(s => s.StartsWith("test"), s => _handledItems.Add(s));
         
         // Act
         var result = _registry.CanHandle("other item");
@@ -154,10 +165,10 @@ public class HandlerRegistryTests
         // Arrange & Act
         Assert.AreEqual(0, _registry.Count);
         
-        _registry.Register(s => s.StartsWith("test"), s => _handledItems.Add(s));
+        _registry.Register<string>(s => s.StartsWith("test"), s => _handledItems.Add(s));
         Assert.AreEqual(1, _registry.Count);
         
-        _registry.Register(s => s.StartsWith("other"), s => _handledItems.Add(s));
+        _registry.Register<string>(s => s.StartsWith("other"), s => _handledItems.Add(s));
         Assert.AreEqual(2, _registry.Count);
     }
 
@@ -165,9 +176,9 @@ public class HandlerRegistryTests
     public void Clear_ShouldRemoveAllHandlersAndClearStash()
     {
         // Arrange
-        _registry.Register(s => s.StartsWith("test"), s => _handledItems.Add(s));
+        _registry.Register<string>(s => s.StartsWith("test"), s => _handledItems.Add(s));
         _registry.Stash();
-        _registry.Register(s => s.StartsWith("other"), s => _handledItems.Add(s));
+        _registry.Register<string>(s => s.StartsWith("other"), s => _handledItems.Add(s));
         
         // Act
         _registry.Clear();
@@ -181,9 +192,9 @@ public class HandlerRegistryTests
     public void GetMatchingHandlers_ShouldReturnAllMatchingHandlers()
     {
         // Arrange
-        _registry.Register(s => s.Contains("test"), _ => _handledItems.Add("first"));
-        _registry.Register(s => s.Contains("test"), _ => _handledItems.Add("second"));
-        _registry.Register(s => s.StartsWith("other"), _ => _handledItems.Add("third"));
+        _registry.Register<string>(s => s.Contains("test"), _ => _handledItems.Add("first"));
+        _registry.Register<string>(s => s.Contains("test"), _ => _handledItems.Add("second"));
+        _registry.Register<string>(s => s.StartsWith("other"), _ => _handledItems.Add("third"));
         var expected = new[] {"first", "second"};
         
         // Act
@@ -204,7 +215,7 @@ public class HandlerRegistryTests
     public void Stash_ShouldSaveCurrentHandlersAndClearRegistry()
     {
         // Arrange
-        _registry.Register(s => s.StartsWith("test"), _ => _handledItems.Add("original"));
+        _registry.Register<string>(s => s.StartsWith("test"), _ => _handledItems.Add("original"));
         
         // Act
         _registry.Stash();
@@ -218,9 +229,9 @@ public class HandlerRegistryTests
     public void Pop_WithStashedHandlers_ShouldRestoreHandlersAndReturnTrue()
     {
         // Arrange
-        _registry.Register(s => s.StartsWith("test"), _ => _handledItems.Add("original"));
+        _registry.Register<string>(s => s.StartsWith("test"), _ => _handledItems.Add("original"));
         _registry.Stash();
-        _registry.Register(s => s.StartsWith("new"), _ => _handledItems.Add("new"));
+        _registry.Register<string>(s => s.StartsWith("new"), _ => _handledItems.Add("new"));
         
         // Act
         var result = _registry.Pop();
@@ -236,7 +247,7 @@ public class HandlerRegistryTests
     public void Pop_WithEmptyStash_ShouldReturnFalse()
     {
         // Arrange
-        _registry.Register(s => s.StartsWith("test"), s => _handledItems.Add(s));
+        _registry.Register<string>(s => s.StartsWith("test"), s => _handledItems.Add(s));
         
         // Act
         var result = _registry.Pop();
@@ -250,13 +261,13 @@ public class HandlerRegistryTests
     public void StashAndPop_ShouldWorkWithMultipleLevels()
     {
         // Arrange
-        _registry.Register(s => s == "level1", _ => _handledItems.Add("level1"));
+        _registry.Register<string>(s => s == "level1", _ => _handledItems.Add("level1"));
         _registry.Stash();
         
-        _registry.Register(s => s == "level2", _ => _handledItems.Add("level2"));
+        _registry.Register<string>(s => s == "level2", _ => _handledItems.Add("level2"));
         _registry.Stash();
         
-        _registry.Register(s => s == "level3", _ => _handledItems.Add("level3"));
+        _registry.Register<string>(s => s == "level3", _ => _handledItems.Add("level3"));
         
         // Act & Assert
         Assert.IsTrue(_registry.CanHandle("level3"));
@@ -280,18 +291,20 @@ public class HandlerRegistryTests
     public void StashAndPop_ShouldReplaceCurrentHandlers()
     {
         // Arrange
-        _registry.Register(s => s == "original", _ => _handledItems.Add("original"));
+        _registry.Register<string>(s => s == "original", _ => _handledItems.Add("original"));
+        _registry.Register<int>(s => true, s => Assert.AreEqual(555, s));
         _registry.Stash();
-        _registry.Register(s => s == "temp1", _ => _handledItems.Add("temp1"));
-        _registry.Register(s => s == "temp2", _ => _handledItems.Add("temp2"));
+        _registry.Register<string>(s => s == "temp1", _ => _handledItems.Add("temp1"));
+        _registry.Register<string>(s => s == "temp2", _ => _handledItems.Add("temp2"));
         
         // Act
         _registry.Pop();
         
         // Assert
-        Assert.AreEqual(1, _registry.Count);
+        Assert.AreEqual(2, _registry.Count);
         Assert.IsTrue(_registry.CanHandle("original"));
         Assert.IsFalse(_registry.CanHandle("temp1"));
         Assert.IsFalse(_registry.CanHandle("temp2"));
+        Assert.IsTrue(_registry.CanHandle(555));
     }
 }


### PR DESCRIPTION
Refactors HandlerRegistry to remove the generic type parameter.

This change simplifies the API by allowing registration of handlers with different types within the same registry. It uses type checking at runtime to ensure correct handler execution. A new test case has also been added to cover registering handlers without conditions.