### PR TITLE
Allows handling of any with object

### DIFF
--- a/src/Servus.Core.Tests/Collections/HandlerRegistryTests.cs
+++ b/src/Servus.Core.Tests/Collections/HandlerRegistryTests.cs
@@ -101,6 +101,27 @@ public class HandlerRegistryTests
     }
 
     [TestMethod]
+    public void Handle_AnyHandler_WithTypeObject()
+    {
+        // Arrange
+        _registry.Register<string>(s => s.Contains("test"), _ => _handledItems.Add("first"));
+        _registry.Register<object>(_ => true, o =>_handledItems.Add("any"));
+        _registry.Register<string>(s => s.Contains("leberkas"), _ => _handledItems.Add("second"));
+        
+        // Act
+        var result = _registry.Handle("test item");
+        var resultAny = _registry.Handle("leberkas");
+        
+        // Assert
+        Assert.IsTrue(result);
+        Assert.AreEqual(2, _handledItems.Count);
+        Assert.AreEqual("first", _handledItems[0]);
+        
+        Assert.IsTrue(resultAny);
+        Assert.AreEqual("any", _handledItems[1]);
+    }
+
+    [TestMethod]
     public void HandleAll_WithMultipleMatchingHandlers_ShouldExecuteAllAndReturnCount()
     {
         // Arrange

--- a/src/Servus.Core/Collections/HandlerRegistry.cs
+++ b/src/Servus.Core/Collections/HandlerRegistry.cs
@@ -107,7 +107,7 @@ public class HandlerRegistry
     public IEnumerable<Action<object>> GetMatchingHandlers(object item)
     {
         return _handlers
-            .Where(i => i.Type.IsAssignableTo(item.GetType()))
+            .Where(i => i.Type.IsAssignableTo(item.GetType()) || i.Type == typeof(object))
             .Where(entry => entry.CanHandle(item))
             .Select(entry => entry.Handler);
     }


### PR DESCRIPTION
Extends the handler registry to allow registration and execution of handlers that accept any object type.

This enables more generic handlers that can process a wider range of inputs.