### PR TITLE
build: add global.json and format csproj

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -6,7 +6,7 @@ on:
     branches: [ "master", "develop" ]
 
 env:
-  DOTNET_VERSION: '8.0.x'
+  GLOBAL_JSON_PATH: './src/global.json'
   PROJECT_PATH: './src/Servus.sln'
   PACKAGE_OUTPUT_DIRECTORY: './packages'
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -30,7 +30,7 @@ jobs:
       - name: Install .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: ${{ env.GLOBAL_JSON_PATH }}
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v1.1.1
@@ -95,7 +95,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: ${{ env.GLOBAL_JSON_PATH }}
 
       - name: Publish to NuGet
         run: |

--- a/src/Servus.Core/Servus.Core.csproj
+++ b/src/Servus.Core/Servus.Core.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  
+
   <PropertyGroup>
     <Authors>Christian Dirnhofer, Andreas Huber, Max Dhom</Authors>
     <Company>Bavaria-Black</Company>
@@ -8,8 +8,8 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://servuscore.readthedocs.io</PackageProjectUrl>
     <RepositoryUrl>https://github.com/Bavaria-Black/servus.core</RepositoryUrl>
-    <RepositoryType>git</RepositoryType> 
-    <Copyright>Copyright (c) Bavaria-Black 2025</Copyright>
+    <RepositoryType>git</RepositoryType>
+    <Copyright>Copyright (c) Bavaria-Black 2025-$([System.DateTime]::Now.Year)</Copyright>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,30 +19,30 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.*" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[9.0.0,)"/>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[9.0.0,)"/>
   </ItemGroup>
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
   </ItemGroup>
   <ItemGroup>
-    <None Include="../../README.md" Pack="true" PackagePath="\" />
-    <None Include="../../docs/src/_static/logo.png" Pack="true" PackagePath="\" />
-    <None Include="../../LICENSE" Pack="true" PackagePath="\"/>
-    <None Include="../../.github/workflows/build-and-release.yml" />
+    <None Include="../../README.md" Pack="true" Visible="false" PackagePath="\"/>
+    <None Include="../../docs/src/_static/logo.png" Pack="true" Visible="false" PackagePath="\"/>
+    <None Include="../../LICENSE" Pack="true" Visible="false" PackagePath="\"/>
+    <None Include="../../.github/workflows/build-and-release.yml"/>
   </ItemGroup>
   <Target Name="ServusLogo" BeforeTargets="Build">
-    <Message Text=" " Importance="high" />
-    <Message Text=" " Importance="high" /> 
-    <Message Text="                                   /\" Importance="high" />
-    <Message Text="                                  /  \" Importance="high" />
-    <Message Text="                                 /    \__" Importance="high" />
-    <Message Text="                           /\   /        \    /\" Importance="high" />
-    <Message Text="                          /  \_/          \__/  \" Importance="high" />
-    <Message Text="                         /                       \" Importance="high" />
-    <Message Text="                        /_________________________\" Importance="high" />
-    <Message Text="                                  servus!" Importance="high" />
-    <Message Text=" " Importance="high" />
-    <Message Text=" " Importance="high" />
+    <Message Text=" " Importance="high"/>
+    <Message Text=" " Importance="high"/>
+    <Message Text="                                   /\" Importance="high"/>
+    <Message Text="                                  /  \" Importance="high"/>
+    <Message Text="                                 /    \__" Importance="high"/>
+    <Message Text="                           /\   /        \    /\" Importance="high"/>
+    <Message Text="                          /  \_/          \__/  \" Importance="high"/>
+    <Message Text="                         /                       \" Importance="high"/>
+    <Message Text="                        /_________________________\" Importance="high"/>
+    <Message Text="                                  servus!" Importance="high"/>
+    <Message Text=" " Importance="high"/>
+    <Message Text=" " Importance="high"/>
   </Target>
 </Project>

--- a/src/Servus.sln
+++ b/src/Servus.sln
@@ -9,6 +9,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Servus.Benchmarks", "Servus
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Servus.Core", "Servus.Core\Servus.Core.csproj", "{DBC75291-D401-4987-AB4A-229CD90CCDA6}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{84876363-7324-472F-B038-153BA1DE5983}"
+	ProjectSection(SolutionItems) = preProject
+		global.json = global.json
+		..\README.md = ..\README.md
+		..\LICENSE = ..\LICENSE
+		..\.github\workflows\build-and-release.yml = ..\.github\workflows\build-and-release.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/global.json
+++ b/src/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}


### PR DESCRIPTION
This PR adds a `global.json` to pin the .NET SDK version for consistent local and CI builds.
Additionally, the project file was reformatted and slightly cleaned up without changing behavior or target frameworks.